### PR TITLE
Add fallback orange to header

### DIFF
--- a/src/css/global.scss
+++ b/src/css/global.scss
@@ -29,6 +29,7 @@ $breakpoint: "(max-width: 600px)";
 
 .site-header,
 .mega-header {
+  background: $orange;
   background:
     linear-gradient(
       to top,


### PR DESCRIPTION
Just trying to do a simple PR (noob here) since the header didn't render on IE for me. 
For browsers which don't support linear-gradients (i.e. IE<10).