### PR TITLE
Allow build changes to be deployed

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,8 @@
+dependencies:
+  pre:
+    - git config user.name "Circle CI"
+    - git config user.email "bot@adorable.io"
+
 deployment:
   production:
     branch: master


### PR DESCRIPTION
The deploy task will, if there are changes to the compiled assets,
attempt to commit and push those. It just so happens that both a) Circle
CI didn't have git configured and b) we did not have any changes to
assets since we started deploying from Circle.

This has been an outstanding issue for a while; this should fix
deployment in those cases.