### PR TITLE
Configure git name/email globally

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 dependencies:
   pre:
-    - git config user.name "Circle CI"
-    - git config user.email "bot@adorable.io"
+    - git config --global user.name "Circle CI"
+    - git config --global user.email "bot@adorable.io"
 
 deployment:
   production:


### PR DESCRIPTION
Our deploy task clones a new copy of the repo, so our local git config
will not apply there, and thus the issues described in #37 still
persist.